### PR TITLE
Remove gb_dispatch from PdfThumbnail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Claude Code artifacts
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ build/
 .rvmrc
 
 # Claude Code artifacts
-.claude/
+.claude/mind.mv2.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -77,7 +76,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -276,8 +275,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -328,7 +325,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.1)
+    json (2.19.4)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -356,9 +353,9 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
     mocha (1.16.1)
@@ -583,7 +580,7 @@ CHECKSUMS
   aws-sdk-s3 (1.216.0) sha256=a3bf6191e6f7a3dfb04b7cc73409f059394be559e4aff92d2a764341e4d90af4
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
@@ -640,7 +637,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2
@@ -661,7 +657,7 @@ CHECKSUMS
   ipaddress (0.8.3) sha256=85640c4f9194c26937afc8c78e3074a8e7c97d5d1210358d1440f01034d006f5
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.1) sha256=dd94fdc59e48bff85913829a32350b3148156bc4fd2a95a2568a78b11344082d
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   kt-paperclip (7.3.0) sha256=fcaed06ba0f553c9814f1d574268baba58334a09731203b603018723a6bba690
@@ -673,9 +669,9 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
   mocha (1.16.1) sha256=d4644238b5b2f4110be81392fe1a468bd784c6cc9012bd274f9065508dfb97cd
   multi_json (1.19.1) sha256=7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -637,7 +637,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2
   google-apis-core (1.0.2) sha256=ba4579aaadc902d6cc7bc8db88f566ab00f5e31ea87ab41e9f9a032c470f2629

--- a/gb-paperclip.gemspec
+++ b/gb-paperclip.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_runtime_dependency 'gb_dispatch', '>=0.1.3'
   s.add_runtime_dependency 'kt-paperclip', '>=6.0'
   s.add_development_dependency('activerecord', '>=7.0')
   s.add_development_dependency('appraisal')

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -671,7 +671,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -116,7 +115,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -313,8 +312,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -397,7 +394,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
@@ -619,7 +616,7 @@ CHECKSUMS
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
@@ -674,7 +671,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
@@ -709,7 +705,7 @@ CHECKSUMS
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -707,7 +707,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -122,7 +121,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -322,8 +321,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -410,7 +407,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
@@ -652,7 +649,7 @@ CHECKSUMS
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
@@ -710,7 +707,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
@@ -745,7 +741,7 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -116,7 +115,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -316,8 +315,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -404,9 +401,9 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
     mocha (1.16.1)
@@ -669,7 +666,7 @@ CHECKSUMS
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
@@ -727,7 +724,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
@@ -762,9 +758,9 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
   mocha (1.16.1) sha256=d4644238b5b2f4110be81392fe1a468bd784c6cc9012bd274f9065508dfb97cd
   multi_json (1.19.1) sha256=7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -724,7 +724,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -719,7 +719,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -114,7 +113,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -313,8 +312,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -401,9 +398,9 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
     mocha (1.16.1)
@@ -665,7 +662,7 @@ CHECKSUMS
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
@@ -722,7 +719,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
@@ -757,9 +753,9 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
   mocha (1.16.1) sha256=d4644238b5b2f4110be81392fe1a468bd784c6cc9012bd274f9065508dfb97cd
   multi_json (1.19.1) sha256=7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    gb_paperclip (2.4.0)
+    gb_paperclip (2.5.0)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -721,7 +721,7 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_paperclip (2.4.0)
+  gb_paperclip (2.5.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   google-apis-compute_v1 (0.142.0) sha256=7129f38209a1a628ea0297d996654dbec7d2adab1f5b13b40693a6448955e7f2

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     gb_paperclip (2.4.0)
-      gb_dispatch (>= 0.1.3)
       kt-paperclip (>= 6.0)
 
 GEM
@@ -116,7 +115,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     bourne (1.6.0)
       mocha (~> 1.1)
     builder (3.3.0)
@@ -315,8 +314,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
-    gb_dispatch (0.1.3)
-      concurrent-ruby (>= 1.0)
     generator_spec (0.10.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -369,7 +366,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.1)
+    json (2.19.4)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -403,9 +400,9 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
     mocha (1.16.1)
@@ -667,7 +664,7 @@ CHECKSUMS
   aws-sdk-s3 (1.216.0) sha256=a3bf6191e6f7a3dfb04b7cc73409f059394be559e4aff92d2a764341e4d90af4
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bourne (1.6.0) sha256=c889471ee13e7aeda661d84a6bb86aa5665b8b69610e949ffde32f419a3a25a5
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
@@ -724,7 +721,6 @@ CHECKSUMS
   fog-xenserver (1.0.0) sha256=1fee6d26500fcaf89b1220008d440807acc9d4804b7a60b5f2b74cc820505855
   fog-xml (0.1.5) sha256=52b9fea10701461dd3eaf9d9839702169b418dbbf50426786b9b74fade373bd6
   formatador (1.2.3) sha256=19fa898133c2c26cdbb5d09f6998c1e137ad9427a046663e55adfe18b950d894
-  gb_dispatch (0.1.3) sha256=f590d360ec3f4600025724c27b33020360dca57a36685426e6dc6c1d4355a993
   gb_paperclip (2.4.0)
   generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
@@ -746,7 +742,7 @@ CHECKSUMS
   ipaddress (0.8.3) sha256=85640c4f9194c26937afc8c78e3074a8e7c97d5d1210358d1440f01034d006f5
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.1) sha256=dd94fdc59e48bff85913829a32350b3148156bc4fd2a95a2568a78b11344082d
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   kt-paperclip (7.3.0) sha256=fcaed06ba0f553c9814f1d574268baba58334a09731203b603018723a6bba690
@@ -759,9 +755,9 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
-  mime-types-data (3.2026.0303) sha256=164af1de5824c5195d4b503b0a62062383b65c08671c792412450cd22d3bc224
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
   mocha (1.16.1) sha256=d4644238b5b2f4110be81392fe1a468bd784c6cc9012bd274f9065508dfb97cd
   multi_json (1.19.1) sha256=7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996

--- a/lib/gb_paperclip/paperclip/pdf_thumbnail.rb
+++ b/lib/gb_paperclip/paperclip/pdf_thumbnail.rb
@@ -3,7 +3,6 @@ require 'gb_paperclip/paperclip/thumbnail'
 require 'gb_paperclip/paperclip/attachment'
 require 'gb_paperclip/paperclip/fake_geometry'
 require 'gb_paperclip/paperclip/geometry_parser'
-require 'gb_dispatch'
 
 module Paperclip
   class PdfThumbnail < Paperclip::Thumbnail
@@ -38,11 +37,8 @@ module Paperclip
 
     def make
       if @attachment
-        queue = @style ? "paperclip_#{@style}" : :paperclip
-        GBDispatch.dispatch_async_on_queue queue do
-          source_path = "#{File.expand_path(@safe_copy.path)}"
-          process_thumbnails source_path
-        end
+        source_path = "#{File.expand_path(@safe_copy.path)}"
+        process_thumbnails source_path
         nil
       else
         super
@@ -80,29 +76,11 @@ module Paperclip
         raise e
       end
       begin
-        while @attachment.is_saving?
-          sleep 0.01
-        end
         @attachment.change_queued_for_write do |queue|
           queue[@style] = Paperclip.io_adapters.for(dst) if dst
         end
-        @attachment.with_save_lock do
-          if @attachment.is_dirty?
-            GBDispatch.dispatch_async_on_queue(:paperclip_upload) do
-              @attachment.finished_processing @style
-            end
-          else
-            GBDispatch.dispatch_async_on_queue(:paperclip_upload) do
-              begin
-                @attachment.flush_writes
-                @attachment.finished_processing @style
-              rescue Exception => e
-                @attachment.failed_processing @style
-                raise e
-              end
-            end
-          end
-        end
+        @attachment.flush_writes unless @attachment.is_dirty?
+        @attachment.finished_processing @style
       rescue Exception => e
         @attachment.failed_processing @style if @attachment && @style
         unlink_files @safe_copy, dst

--- a/lib/gb_paperclip/version.rb
+++ b/lib/gb_paperclip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GBPaperclip
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
 end

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -17,42 +17,6 @@ describe Paperclip::Attachment do
     @attachment   = @dummy.avatar
   end
 
-  context 'saving with lock' do
-    it 'should put save lock while saving' do
-      async_flag                          = false
-      @attachment.queued_for_write[:test] = Paperclip.io_adapters.for(@file)
-      GBDispatch.dispatch_async(:test) do
-        @attachment.with_save_lock do
-          sleep(0.02)
-          async_flag = true
-        end
-      end
-      sleep(0.001)
-      GBDispatch.dispatch_sync(:save) do
-        @dummy.save
-      end
-      expect(async_flag).to eq true
-      wait_for :test
-    end
-
-    it 'should use status lock' do
-      async_flag                          = false
-      @attachment.queued_for_write[:test] = Paperclip.io_adapters.for(@file)
-      GBDispatch.dispatch_async(:test) do
-        @attachment.send(:status_lock).lock
-        sleep(0.3)
-        async_flag = true
-        @attachment.send(:status_lock).unlock
-      end
-      sleep(0.1)
-      GBDispatch.dispatch_sync :save do
-        sleep(0.05)
-        @attachment.save
-      end
-      expect(async_flag).to eq true
-    end
-  end
-
   it 'unlink files should handle nil values' do
     file = File.new(fixture_file('5k.png'), 'rb')
     expect { @attachment.unlink_files([file, nil]) }.not_to raise_error
@@ -100,34 +64,6 @@ describe Paperclip::Attachment do
           expect(@dummy.changes.keys).not_to include 'processing'
         end
 
-        it 'should save if saving on different thread' do
-          unless  defined? SleepyDummy
-            class SleepyDummy < Dummy
-              self.table_name = 'dummies'
-              after_save :take_nap
-
-              def take_nap
-                sleep(0.015)
-              end
-            end
-          end
-          dummy = nil
-          GBDispatch.dispatch_sync(:save) do
-            dummy        = SleepyDummy.new
-            dummy.avatar = @file
-          end
-          GBDispatch.dispatch_async(:save) do
-            dummy.save!
-          end
-          GBDispatch.dispatch_sync(:process) do
-            sleep(0.001)
-            expect { dummy.avatar.processing(:test_style) }.not_to raise_error
-          end
-          wait_for :save
-          expect(dummy.avatar.saved[:original]).not_to be_nil
-          expect(dummy.changes.keys.any?).to be_falsey
-          expect(dummy.reload.processing).to eq true
-        end
       end
     end
 
@@ -148,23 +84,6 @@ describe Paperclip::Attachment do
     end
 
     context 'saving processing info' do
-      it 'should use save lock' do
-        async_flag = false
-        @attachment.instance_variable_set :@processed_styles, [:foo, :bar]
-        GBDispatch.dispatch_async(:test) do
-          @attachment.with_save_lock do
-            sleep(0.02)
-            async_flag = true
-          end
-        end
-        GBDispatch.dispatch_sync :save do
-          sleep(0.001)
-          @attachment.send :save_processing_info
-        end
-        expect(async_flag).to eq true
-        wait_for :test
-      end
-
       it 'should set proper value for new object' do
         dummy = Dummy.new
         dummy.avatar.instance_variable_set :@processed_styles, [:foo, :bar]
@@ -195,42 +114,6 @@ describe Paperclip::Attachment do
         expect(@dummy.processed_styles).to eq [:foo, :bar]
       end
 
-      100.times do |counter|
-        it "should save if saving on different thread #{counter}" do
-          unless defined? SleepyDummy
-            class SleepyDummy < Dummy
-              self.table_name = 'dummies'
-              after_save :take_nap
-
-              def take_nap
-                sleep(0.015)
-              end
-            end
-          end
-          dummy  = nil
-          status = nil
-          GBDispatch.dispatch_sync(:save) do
-            dummy        = SleepyDummy.new
-            dummy.avatar = @file
-          end
-          GBDispatch.dispatch_async(:save) do
-            Dummy.transaction do
-              status = dummy.save!
-            end
-          end
-          GBDispatch.dispatch_sync(:process) do
-            sleep(0.001)
-            dummy.avatar.instance_variable_set :@processed_styles, [:foo, :bar]
-            expect { dummy.avatar.send :save_processing_info }.not_to raise_error
-          end
-          wait_for :save
-          expect(dummy.avatar.saved[:original]).not_to be_nil
-          expect(status).to be_truthy
-          expect(dummy.changes.keys).to eq []
-          expect(dummy.reload.processing).to eq false
-          expect(dummy.processed_styles).to eq [:foo, :bar]
-        end
-      end
     end
 
     context 'set processing info' do
@@ -387,9 +270,4 @@ describe Paperclip::Attachment do
     end
   end
 
-  def wait_for(queue)
-    GBDispatch.dispatch_sync_on_queue queue do
-      puts "waiting for #{queue}"
-    end
-  end
 end

--- a/spec/paperclip/pdf_thumbnail_spec.rb
+++ b/spec/paperclip/pdf_thumbnail_spec.rb
@@ -284,14 +284,13 @@ describe Paperclip::PdfThumbnail do
     end
   end
 
-  context 'async' do
+  context 'with attachment' do
     context 'An normal pdf' do
       before do
         @file = File.new(fixture_file('twopage.pdf'), 'rb')
         rebuild_model storage: :fake
         @dummy      = Dummy.new
         @attachment = @dummy.avatar
-        wait_for_make
       end
 
       after { @file.close }
@@ -319,8 +318,6 @@ describe Paperclip::PdfThumbnail do
             before do
               stub_attachment
               @thumb.make
-              wait_for_make
-              wait_for_save
               @thumb_result = @attachment.saved[:test]
             end
 
@@ -384,14 +381,11 @@ describe Paperclip::PdfThumbnail do
             hash_including(source: "#{File.expand_path(@thumb.safe_copy.path)}[0]")
           )
           @thumb.make
-          wait_for_make
         end
 
         it 'creates the thumbnail when sent #make' do
           stub_attachment
           @thumb.make
-          wait_for_make
-          wait_for_save
           dst = @attachment.saved[:test]
           assert_match /100x50/, `identify "#{dst.path}"`
           dst.close
@@ -404,8 +398,6 @@ describe Paperclip::PdfThumbnail do
         thumb = Paperclip::PdfThumbnail.new(file, { geometry: '50x50#', style: :test }, @attachment)
 
         thumb.make
-        wait_for_make
-        wait_for_save
         output_file = @attachment.saved[:test]
 
         command = Terrapin::CommandLine.new('identify', '-format %wx%h :file')
@@ -432,14 +424,11 @@ describe Paperclip::PdfThumbnail do
             hash_including(source: "#{File.expand_path(@thumb.safe_copy.path)}[0]")
           )
           @thumb.make
-          wait_for_make
         end
 
         it 'creates the thumbnail when sent #make' do
           stub_attachment
           @thumb.make
-          wait_for_make
-          wait_for_save
           dst = @attachment.saved[:test]
           assert_match /100x50/, `identify "#{dst.path}"`
           dst.close
@@ -482,14 +471,11 @@ describe Paperclip::PdfThumbnail do
             hash_including(source: "#{File.expand_path(@thumb.safe_copy.path)}[0]")
           )
           @thumb.make
-          wait_for_make
         end
 
         it 'creates the thumbnail when sent #make' do
           stub_attachment
           @thumb.make
-          wait_for_make
-          wait_for_save
           dst = @attachment.saved[:test]
           assert_match /100x50/, `identify "#{dst.path}"`
           dst.close
@@ -595,7 +581,6 @@ describe Paperclip::PdfThumbnail do
         @dummy      = Dummy.new
         @attachment = @dummy.avatar
         @thumb      = Paperclip::PdfThumbnail.new(@file, { geometry: '100x50#', style: :test }, @attachment)
-        wait_for_make
       end
 
       after(:each) { @file.close }
@@ -603,15 +588,12 @@ describe Paperclip::PdfThumbnail do
       it 'should call finished processing style if successes' do
         expect(@attachment).to receive(:finished_processing).with(:test)
         @thumb.make
-        wait_for_make
-        wait_for_save
       end
 
       it 'should call finished processing style if successes and is_dirty' do
         expect(@attachment).to receive(:finished_processing).with(:test)
         allow(@attachment).to receive(:is_dirty?).and_return(true)
         @thumb.make
-        wait_for_make
       end
 
       context 'should call failed processing style if' do
@@ -678,10 +660,4 @@ describe Paperclip::PdfThumbnail do
   def stub_attachment
     @attachment.instance_eval 'def after_flush_writes; end'
   end
-
-  # PdfThumbnail#make runs synchronously now, so these are no-ops preserved
-  # to keep the diff minimal. Existing `wait_for_make` / `wait_for_save` call
-  # sites can be removed in a follow-up cleanup.
-  def wait_for_make; end
-  def wait_for_save; end
 end

--- a/spec/paperclip/pdf_thumbnail_spec.rb
+++ b/spec/paperclip/pdf_thumbnail_spec.rb
@@ -347,11 +347,9 @@ describe Paperclip::PdfThumbnail do
             Terrapin::CommandLine.path        = ''
             Paperclip.options[:command_path] = ''
             ENV['PATH']                      = ''
-            silence_stream(STDERR) do
-              @thumb.make
-            end
-            wait_for_make
-            wait_for_save
+            expect do
+              silence_stream(STDERR) { @thumb.make }
+            end.to raise_error(Paperclip::Errors::CommandNotFoundError)
             expect(@attachment.instance.processing).to be_falsey
             expect(@attachment.instance.processed_styles ||= []).not_to include(:test, 'test')
           ensure
@@ -457,10 +455,9 @@ describe Paperclip::PdfThumbnail do
           end
 
           it 'errors when trying to create the thumbnail' do
-            silence_stream(STDERR) do
-              @thumb.make
-            end
-            wait_for_make
+            expect do
+              silence_stream(STDERR) { @thumb.make }
+            end.to raise_error(Paperclip::Error)
             expect(@dummy.processing).to be_falsey
             expect(@dummy.processed_styles ||= []).not_to include(:test, 'test')
           end
@@ -506,11 +503,9 @@ describe Paperclip::PdfThumbnail do
           end
 
           it 'errors when trying to create the thumbnail' do
-            silence_stream(STDERR) do
-              @thumb.make
-            end
-            wait_for_make
-            wait_for_save
+            expect do
+              silence_stream(STDERR) { @thumb.make }
+            end.to raise_error(Paperclip::Error)
             expect(@dummy.processing).to be_falsey
             expect(@dummy.processed_styles ||= []).not_to include(:test, 'test')
           end
@@ -623,8 +618,7 @@ describe Paperclip::PdfThumbnail do
         it 'image magick have wrong params' do
           expect(@attachment).to receive(:failed_processing).with(:test)
           allow(@thumb).to receive(:convert).with(anything, anything).and_raise(Terrapin::ExitStatusError.new '')
-          expect { @thumb.make }.not_to raise_error
-          wait_for_make
+          expect { @thumb.make }.to raise_error(Paperclip::Error)
         end
 
         it 'image magick error' do
@@ -639,8 +633,7 @@ describe Paperclip::PdfThumbnail do
               silence_stream(STDERR) do
                 @thumb.make
               end
-            end.not_to raise_error Paperclip::Errors::CommandNotFoundError
-            wait_for_make
+            end.to raise_error(Paperclip::Errors::CommandNotFoundError)
           ensure
             ENV['PATH'] = old_path
           end
@@ -649,23 +642,13 @@ describe Paperclip::PdfThumbnail do
         it 'convert throws any error' do
           expect(@attachment).to receive(:failed_processing).with(:test)
           allow(@thumb).to receive(:convert).with(anything, anything).and_raise('test error')
-          expect { @thumb.make }.not_to raise_error
-          wait_for_make
+          expect { @thumb.make }.to raise_error('test error')
         end
 
         it 'save throws any error' do
           expect(@attachment).to receive(:failed_processing).with(:test)
-          allow(@attachment).to receive(:flush_writes).with(anything).and_raise('test error')
-          expect { @thumb.make }.not_to raise_error
-          wait_for_make
-          wait_for_save
-        end
-
-        it 'attachment throw error' do
-          expect(@attachment).to receive(:failed_processing).with(:test)
-          allow(@attachment).to receive(:is_saving?).and_raise('test error')
-          @thumb.make
-          wait_for_make
+          allow(@attachment).to receive(:flush_writes).and_raise('test error')
+          expect { @thumb.make }.to raise_error('test error')
         end
       end
     end
@@ -684,36 +667,9 @@ describe Paperclip::PdfThumbnail do
         @file.close
       end
 
-      it 'should wait if files being saved right now' do
-        @attachment.instance_variable_set :@is_saving, true
-        @attachment.instance_variable_set :@dirty, false
-        @thumb.make
-        sleep(0.5)
-        expect(@attachment.saved[:test]).to be_nil
-        @attachment.instance_variable_set :@is_saving, false
-        wait_for_make
-        wait_for_save
-        expect(@attachment.saved[:test]).to be_truthy
-      end
-
-      it 'should not make deadlock if is dirty' do
-        @dummy.save!
-        @attachment.processing :test
-        @attachment.instance_variable_set :@dirty, true
-        @thumb.make
-        sleep(0.5)
-        expect(@attachment.saved[:test]).to be_nil
-        @attachment.instance_variable_set :@is_saving, false
-        wait_for_make
-        wait_for_save
-        expect(@dummy.processed_styles).to include :test
-      end
-
       it 'should save files if attachment is not dirty' do
         @attachment.instance_variable_set :@dirty, false
         @thumb.make
-        wait_for_make
-        wait_for_save
         expect(@attachment.saved[:test]).to be_truthy
       end
     end
@@ -723,15 +679,9 @@ describe Paperclip::PdfThumbnail do
     @attachment.instance_eval 'def after_flush_writes; end'
   end
 
-  def wait_for_make
-    GBDispatch.dispatch_sync_on_queue :paperclip_test do
-      puts 'waiting for make'
-    end
-  end
-
-  def wait_for_save
-    GBDispatch.dispatch_sync_on_queue :paperclip_upload do
-      puts 'waiting for save'
-    end
-  end
+  # PdfThumbnail#make runs synchronously now, so these are no-ops preserved
+  # to keep the diff minimal. Existing `wait_for_make` / `wait_for_save` call
+  # sites can be removed in a follow-up cleanup.
+  def wait_for_make; end
+  def wait_for_save; end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require 'mocha/api'
 require 'bourne'
 require 'ostruct'
 require 'simplecov'
-require 'gb_dispatch'
 require 'aws-sdk-s3'
 require 'aws-sdk-glacier'
 
@@ -68,13 +67,10 @@ if ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR < 2
   end
 end
 
-require 'gb_dispatch/active_record_patch'
-
 FIXTURES_DIR              = File.join(File.dirname(__FILE__), 'fixtures')
 ActiveRecord::Base.logger = Logger.new("#{File.dirname(__FILE__)}/debug.log")
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'file::memory:?cache=shared', pool: 5)
 
-GBDispatch.logger = Logger.new($stdout)
 Paperclip.options[:logger] = ActiveRecord::Base.logger
 Paperclip::DataUriAdapter.register
 Paperclip::UriAdapter.register


### PR DESCRIPTION
## Summary

Two commits:

1. **Remove gb_dispatch from PdfThumbnail** — run `PdfThumbnail#make` synchronously instead of dispatching PDF conversion + `flush_writes`/`finished_processing` to background threads. Collapse the polling `while is_saving?` + `with_save_lock` coordination.

2. **Remove gb_dispatch dependency entirely** — now that nothing in the library uses it:
   - Drop `gb_dispatch` runtime dep from `gb-paperclip.gemspec`
   - Drop `gb_dispatch` requires and logger setup from `spec_helper.rb`
   - Delete async-specific tests from `attachment_spec.rb` (the `saving with lock` context, `should save if saving on different thread`, `should use save lock`, and the 100-iteration race-condition loop — the latter a frequent CI flake source)
   - Delete `wait_for_make`/`wait_for_save` no-op helpers and their 21 call sites in `pdf_thumbnail_spec.rb`; rename the misleading `context 'async'` to `context 'with attachment'`
   - Regenerate `Gemfile.lock` + all 5 `gemfiles/*.lock`

## Why

Upstream consumer `genieplanner-server` was hitting `PG::UnableToSend: another command is already in progress` in CI after bumping `gb_dispatch` past 0.1.2 (which removed the `force_new_connection` monkey-patch). Root cause: under Rails 7.2+ and `use_transactional_fixtures`, the test thread's connection gets pinned via `@pinned_connection` + `@leases` — the `gb_dispatch` worker thread can no longer grab a separate connection, so both threads race on the same Postgres socket.

Removing the async entirely permanently sidesteps the problem. `PdfThumbnail` was the only asymmetric consumer: `video_thumbnail.rb` has always been synchronous.

## What's kept

The `SaveExtension` locking machinery in `attachment.rb` (`with_save_lock`, `with_lock`, `with_status_lock`, `is_saving?`, `change_queued_for_write`) stays in place. It's still used by:
- `has_attached_file.rb` `around_save` hook
- `save_processing_info` → `async_post_process` callback chain (consumer `genieplanner-server/app/models/attachment.rb:64` uses `after_async_post_process :trigger_soft_update`)
- `genieplanner-server/config/initializers/paperclip.rb` (wraps `with_save_lock` + `change_queued_for_write` with InfluxReporter trace)
- `lib/gb_paperclip/paperclip/storage/multiple_storage.rb`

In single-threaded execution the locks become no-ops but they remain semantically valid.

## Tradeoffs

- **PDF convert + S3 upload now block the caller** (previously fired-and-forgot via gb_dispatch). Fine for Sidekiq-driven processing; worse if a caller invokes `make` from a user-facing request and can't tolerate the latency. **Consumer action item (genieplanner-server):** wrap PDF thumbnail generation in a Sidekiq job.
- **Lost global serialization on `:paperclip_upload`** — N concurrent requests now do N parallel S3 uploads. S3 handles this fine.
- **Errors propagate now.** The old code swallowed exceptions inside the gb_dispatch worker thread. In sync, convert errors / S3 errors propagate out of `make`. Callers that relied on "make never raises" will need a rescue.

## Test plan

- [x] Full suite passes on `gemfiles/rails_7_0.gemfile` (253 examples, 0 failures)
- [x] Full suite passes on `gemfiles/rails_7_1.gemfile` (253 examples, 0 failures)
- [x] Full suite passes on `gemfiles/rails_7_2.gemfile` (253 examples, 0 failures)
- [x] Full suite passes on `gemfiles/rails_8_0.gemfile` (253 examples, 0 failures)
- [x] Full suite passes on `gemfiles/rails_8_1.gemfile` (253 examples, 0 failures)
- [ ] CI green across the Rails matrix
- [ ] Before merging: grep `genieplanner-server` for any caller that depends on `make` returning before processing completes

Test count dropped from 357 → 253 because the deleted tests (mostly the 100-iteration flaky race loop) no longer correspond to real behavior in sync mode.

## Follow-ups (separate PR on genieplanner-server)

- Wrap PDF thumbnail generation in a Sidekiq job to restore the off-request-thread latency profile.
- Drop the `gb_dispatch < 0.1.3` pin in the main `Gemfile` once this PR releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)